### PR TITLE
Delete "fully managed" because customer must manually manage server capacity #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Connected Platform – Integrating Sales and Service with AWS Neptune
 
-Deciphering and exploring relationships that exists between sales and service can help companies drive revenue.   AWS Neptune can help companies realize and explore trends, make better recommendations, and easily navigate highly connected and complex datasets.  Amazon Neptune is a fast, reliable, fully managed graph database service that makes it easy to build and run applications.  Neptune can serve as an asset management platform, connecting sales and service data across the organization.
+Deciphering and exploring relationships that exists between sales and service can help companies drive revenue.   AWS Neptune can help companies realize and explore trends, make better recommendations, and easily navigate highly connected and complex datasets.  Amazon Neptune is a fast, reliable, managed graph database service that makes it easy to build and run applications.  Neptune can serve as an asset management platform, connecting sales and service data across the organization.
 
 In this workshop, we will build a connected graph that integrates sales and service data using AWS Neptune.  Once the graph is built, we will explore how sales analysts can use sale and service data in Neptune to identify additional sales opportunities.
 


### PR DESCRIPTION
*Issue #, if available:* #2 

The README for the project contained false advertising which stated AWS Neptune is fully managed. This is false advertising because AWS Neptune does not manage capacity scaling. The customer must manually manage the monitoring and scaling of the database capacity. If AWS neptune were fully managed then the customer would not need to manually manage the monitoring and scaling of the database capacity.

*Description of changes:*
Delete 1 word, "fully" 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
